### PR TITLE
Fix payment info template issue in pdfs

### DIFF
--- a/src/Plugin/PaymentInfoBlockPlugin.php
+++ b/src/Plugin/PaymentInfoBlockPlugin.php
@@ -4,27 +4,27 @@ namespace Fooman\PrintOrderPdf\Plugin;
 
 class PaymentInfoBlockPlugin
 {
-
     private $replacedTemplates = [
         'Magento_Payment::info/pdf/default.phtml' => 'Fooman_PrintOrderPdf::info/pdf/default.phtml',
         'Magento_OfflinePayments::pdf/checkmo.phtml' => 'Fooman_PrintOrderPdf::info/pdf/checkmo.phtml',
         'Magento_OfflinePayments::pdf/purchaseorder.phtml' => 'Fooman_PrintOrderPdf::info/pdf/purchaseorder.phtml',
+        'Magento_OfflinePayments::info/pdf/checkmo.phtml' => 'Fooman_PrintOrderPdf::info/pdf/checkmo.phtml',
+        'Magento_OfflinePayments::info/pdf/purchaseorder.phtml' => 'Fooman_PrintOrderPdf::info/pdf/purchaseorder.phtml',
     ];
 
     /**
-     * when creating a pdf from a frontend context, the admin pdf template is not found
-     * use the copy provided by this extension in the base folder instead
+     * Correctly change template file based on the current template file
      *
-     * @return mixed
+     * @param \Magento\Payment\Block\Info $subject
+     * @return null
      */
-    public function aroundToPdf(
-        \Magento\Payment\Block\Info $subject,
-        \Closure $proceed
-    ) {
+    public function beforeToHtml(\Magento\Payment\Block\Info $subject) {
         $currentTemplate = $subject->getTemplate();
+
         if (isset($this->replacedTemplates[$currentTemplate])) {
             $subject->setTemplate($this->replacedTemplates[$currentTemplate]);
         }
-        return $subject->toHtml();
+
+        return null;
     }
 }


### PR DESCRIPTION
Correctly change the payment info block template.

The logic is moved to "beforeToHtml" because the templates are set in method "toPdf" which is never called because "aroundToPdf" never called original method and the overwrites can't me matched which caused an incorrect template being used on frontend when the order pdf is attached to order confirmation email.

Attached/corrected additional template files.

The changes are based on:
1. https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Payment/Block/Info.php#L61
2. https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/OfflinePayments/Block/Info/Checkmo.php#L67
3. https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/OfflinePayments/Block/Info/Purchaseorder.php#L20